### PR TITLE
Fix sibling names in shield config

### DIFF
--- a/boards/shields/avalanche/avalanche.zmk.yml
+++ b/boards/shields/avalanche/avalanche.zmk.yml
@@ -9,5 +9,5 @@ features:
   - keys
   - display
 siblings:
-  - avalanche_v4_left
-  - avalanche_v4_right
+  - avalanche_left
+  - avalanche_right


### PR DESCRIPTION
## Summary
- correct sibling shield names

## Testing
- `python3 - <<'EOF'
import yaml
with open('boards/shields/avalanche/avalanche.zmk.yml') as f:
    d=yaml.safe_load(f)
print('siblings:', d.get('siblings'))
EOF`

------
https://chatgpt.com/codex/tasks/task_e_686896549148832cbd3e415901bb850c